### PR TITLE
.github/workflows: add atlas ci workflow

### DIFF
--- a/.github/workflows/ci-atlas.yaml
+++ b/.github/workflows/ci-atlas.yaml
@@ -1,0 +1,53 @@
+name: Atlas
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - .github/workflows/ci-atlas.yaml
+      - 'migrations/*'
+  pull_request:
+    paths:
+      - 'migrations/*'
+# Permissions to write comments on the pull request.
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  atlas:
+    services:
+      # Spin up a postgres:15 container to be used as the dev-database for analysis.
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: dev
+          POSTGRES_PASSWORD: pass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-start-period 10s
+          --health-timeout 5s
+          --health-retries 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ariga/setup-atlas@v0
+        with:
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN_ON89U3 }}
+      - uses: ariga/atlas-action/migrate/lint@v1
+        with:
+          dir: 'file://migrations'
+          dir-name: 'curlarc'
+          dev-url: 'postgres://postgres:pass@localhost:5432/dev?search_path=public&sslmode=disable'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - uses: ariga/atlas-action/migrate/push@v1
+        if: github.ref == 'refs/heads/develop'
+        with:
+            dir: 'file://migrations'
+            dir-name: 'curlarc'
+            dev-url: 'postgres://postgres:pass@localhost:5432/dev?search_path=public&sslmode=disable'


### PR DESCRIPTION
PR created by the `gh atlas init-action` command.
 for more information visit https://github.com/ariga/gh-atlas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an automated workflow for database migrations using Atlas, enhancing deployment efficiency.
- **Chores**
	- Added a new GitHub Actions workflow configuration for managing migration tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->