### PR TITLE
Feat/invitied members api

### DIFF
--- a/internal/domain/repository/userTeam.go
+++ b/internal/domain/repository/userTeam.go
@@ -4,8 +4,9 @@ import "CurlARC/internal/domain/entity"
 
 type UserTeamRepository interface {
 	Save(userTeam *entity.UserTeam) (*entity.UserTeam, error)
-	FindUsersByTeamId(teamId string) ([]string, error)   // All users including INVITED users
-	FindMembersByTeamId(teamId string) ([]string, error) // Only MEMBERS
+	FindUsersByTeamId(teamId string) ([]string, error)        // All users including INVITED users
+	FindMembersByTeamId(teamId string) ([]string, error)      // Only MEMBERS
+	FindInvitedUsersByTeamId(teamId string) ([]string, error) // Only INVITED users
 	FindTeamsByUserId(userId string) ([]string, error)
 	FindInvitedTeamsByUserId(userId string) ([]string, error) // Only INVITED teams
 	UpdateState(userTeam *entity.UserTeam) (*entity.UserTeam, error)

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -43,6 +43,7 @@ func InitRouting(
 	teamGroup.POST("/", teamHandler.CreateTeam())
 	teamGroup.GET("/", teamHandler.GetAllTeams())
 	teamGroup.GET("/:teamId/members", teamHandler.GetMembers())
+	teamGroup.GET("/:teamId/invited", teamHandler.GetInvitedUsers())
 	teamGroup.GET("/:teamId/details", teamHandler.GetTeamDetails())
 	teamGroup.PATCH("/:teamId", teamHandler.UpdateTeam())
 	teamGroup.DELETE("/:teamId", teamHandler.DeleteTeam())
@@ -68,4 +69,5 @@ func InitRouting(
 	debug.GET("/teams/:teamId", teamHandler.GetMembers())
 	debug.PATCH("/teams/:teamId/:userId", teamHandler.AcceptInvitation())
 	debug.DELETE("/teams/:teamId/:userId", teamHandler.RemoveMember())
+
 }

--- a/internal/handler/teamHandler.go
+++ b/internal/handler/teamHandler.go
@@ -430,6 +430,41 @@ func (h *TeamHandler) GetMembers() echo.HandlerFunc {
 	}
 }
 
+func (h *TeamHandler) GetInvitedUsers() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		teamID := c.Param("teamId")
+
+		users, err := h.teamUsecase.GetInvitedUsersByTeamId(teamID)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, response.ErrorResponse{
+				Status: "error",
+				Error: response.ErrorDetail{
+					Code:    http.StatusInternalServerError,
+					Message: err.Error(),
+				},
+			})
+		}
+
+		responseUsers := make([]response.User, 0, len(users))
+		for _, user := range users {
+			responseUsers = append(responseUsers, response.User{
+				Id:    user.GetId().Value(),
+				Name:  user.GetName(),
+				Email: user.GetEmail(),
+			})
+		}
+
+		return c.JSON(http.StatusOK, response.SuccessResponse{
+			Status: "success",
+			Data: struct {
+				Users []response.User `json:"users"`
+			}{
+				Users: responseUsers,
+			},
+		})
+	}
+}
+
 // GetTeamDetails retrieves detailed information about a team.
 // @Summary Get team details
 // @Description Retrieves detailed information about a specific team

--- a/internal/infra/userTeam.go
+++ b/internal/infra/userTeam.go
@@ -60,7 +60,7 @@ func (userTeamRepo *UserTeamRepository) FindUsersByTeamId(teamId string) ([]stri
 
 func (userTeamRepo *UserTeamRepository) FindMembersByTeamId(teamId string) ([]string, error) {
 	var userTeams []*UserTeam
-	result := userTeamRepo.SqlHandler.Conn.Where("team_id = ? AND state = ?", teamId, "MEMBER").Find(&userTeams)
+	result := userTeamRepo.SqlHandler.Conn.Where("team_id = ? AND state = ?", teamId, entity.Member).Find(&userTeams)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -76,7 +76,7 @@ func (userTeamRepo *UserTeamRepository) FindMembersByTeamId(teamId string) ([]st
 
 func (userTeamRepo *UserTeamRepository) FindInvitedUsersByTeamId(teamId string) ([]string, error) {
 	var userTeams []*UserTeam
-	result := userTeamRepo.SqlHandler.Conn.Where("team_id = ? AND state = ?", teamId, "INVITED").Find(&userTeams)
+	result := userTeamRepo.SqlHandler.Conn.Where("team_id = ? AND state = ?", teamId, entity.Invited).Find(&userTeams)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -92,7 +92,7 @@ func (userTeamRepo *UserTeamRepository) FindInvitedUsersByTeamId(teamId string) 
 
 func (userTeamRepo *UserTeamRepository) FindTeamsByUserId(userId string) ([]string, error) {
 	var userTeams []*UserTeam
-	result := userTeamRepo.SqlHandler.Conn.Where("user_id = ? AND state = ?", userId, "MEMBER").Find(&userTeams)
+	result := userTeamRepo.SqlHandler.Conn.Where("user_id = ? AND state = ?", userId, entity.Member).Find(&userTeams)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -108,7 +108,7 @@ func (userTeamRepo *UserTeamRepository) FindTeamsByUserId(userId string) ([]stri
 
 func (userTeamRepo *UserTeamRepository) FindInvitedTeamsByUserId(userId string) ([]string, error) {
 	var userTeams []*UserTeam
-	result := userTeamRepo.SqlHandler.Conn.Where("user_id = ? AND state = ?", userId, "INVITED").Find(&userTeams)
+	result := userTeamRepo.SqlHandler.Conn.Where("user_id = ? AND state = ?", userId, entity.Invited).Find(&userTeams)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -161,5 +161,5 @@ func (userTeamRepo *UserTeamRepository) IsMember(userId, teamId string) (bool, e
 		return false, result.Error
 	}
 
-	return userTeam.State == "MEMBER", nil
+	return userTeam.State == string(entity.Member), nil
 }

--- a/internal/infra/userTeam.go
+++ b/internal/infra/userTeam.go
@@ -74,6 +74,22 @@ func (userTeamRepo *UserTeamRepository) FindMembersByTeamId(teamId string) ([]st
 	return userIds, nil
 }
 
+func (userTeamRepo *UserTeamRepository) FindInvitedUsersByTeamId(teamId string) ([]string, error) {
+	var userTeams []*UserTeam
+	result := userTeamRepo.SqlHandler.Conn.Where("team_id = ? AND state = ?", teamId, "INVITED").Find(&userTeams)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	var userIds []string
+	for _, userTeam := range userTeams {
+		userIds = append(userIds, userTeam.UserId)
+	}
+
+	return userIds, nil
+}
+
 func (userTeamRepo *UserTeamRepository) FindTeamsByUserId(userId string) ([]string, error) {
 	var userTeams []*UserTeam
 	result := userTeamRepo.SqlHandler.Conn.Where("user_id = ? AND state = ?", userId, "MEMBER").Find(&userTeams)

--- a/internal/usecase/team.go
+++ b/internal/usecase/team.go
@@ -18,10 +18,12 @@ type TeamUsecase interface {
 	InviteUsers(teamId, userId string, targetUserEmails []string) error
 	AcceptInvitation(teamId, userId string) error
 	RemoveMember(teamId, userId string) error
+	GetDetailsByTeamId(teamId string) (*entity.Team, error)
+	GetMembersByTeamId(teamId string) ([]*entity.User, error)
+	GetInvitedUsersByTeamId(teamId string) ([]*entity.User, error)
+
 	GetTeamsByUserId(userId string) ([]*entity.Team, error)
 	GetInvitedTeams(userId string) ([]*entity.Team, error)
-	GetMembersByTeamId(teamId string) ([]*entity.User, error)
-	GetDetailsByTeamId(teamId string) (*entity.Team, error)
 }
 
 type teamUsecase struct {
@@ -234,6 +236,24 @@ func (usecase *teamUsecase) GetInvitedTeams(userId string) ([]*entity.Team, erro
 
 func (usecase *teamUsecase) GetMembersByTeamId(teamId string) ([]*entity.User, error) {
 	userIds, err := usecase.userTeamRepo.FindMembersByTeamId(teamId)
+	if err != nil {
+		return nil, err
+	}
+
+	var users []*entity.User
+	for _, userId := range userIds {
+		user, err := usecase.userRepo.FindById(userId)
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, user)
+	}
+
+	return users, nil
+}
+
+func (usecase *teamUsecase) GetInvitedUsersByTeamId(teamId string) ([]*entity.User, error) {
+	userIds, err := usecase.userTeamRepo.FindInvitedUsersByTeamId(teamId)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/team.go
+++ b/internal/usecase/team.go
@@ -137,7 +137,6 @@ func (usecase *teamUsecase) InviteUsers(teamId, userId string, targetUserEmails 
 			continue
 		}
 
-		// Add user to team with "INVITED" state
 		userTeam := entity.NewUserTeam(*entity.NewUserId(targetUser.GetId().Value()), *entity.NewTeamId(teamId), entity.Invited)
 		_, err = usecase.userTeamRepo.Save(userTeam)
 		if err != nil {
@@ -167,7 +166,7 @@ func (usecase *teamUsecase) AcceptInvitation(teamId, userId string) error {
 		return err
 	}
 
-	userTeam := entity.NewUserTeam(*entity.NewUserId(userId), *entity.NewTeamId(teamId), "MEMBER")
+	userTeam := entity.NewUserTeam(*entity.NewUserId(userId), *entity.NewTeamId(teamId), entity.Member)
 
 	// Update state of user-team
 	_, err = usecase.userTeamRepo.UpdateState(userTeam)

--- a/internal/usecase/team.go
+++ b/internal/usecase/team.go
@@ -252,12 +252,23 @@ func (usecase *teamUsecase) GetMembersByTeamId(teamId string) ([]*entity.User, e
 }
 
 func (usecase *teamUsecase) GetInvitedUsersByTeamId(teamId string) ([]*entity.User, error) {
+	// Validate team existence
+	_, err := usecase.teamRepo.FindById(teamId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid teamId: %w", err)
+	}
+
 	userIds, err := usecase.userTeamRepo.FindInvitedUsersByTeamId(teamId)
 	if err != nil {
 		return nil, err
 	}
 
-	var users []*entity.User
+	if len(userIds) == 0 {
+		return []*entity.User{}, nil
+	}
+
+	users := make([]*entity.User, 0, len(userIds))
+
 	for _, userId := range userIds {
 		user, err := usecase.userRepo.FindById(userId)
 		if err != nil {

--- a/mock/mock_repository_userTeam.go
+++ b/mock/mock_repository_userTeam.go
@@ -63,6 +63,21 @@ func (mr *MockUserTeamRepositoryMockRecorder) FindInvitedTeamsByUserId(userId in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindInvitedTeamsByUserId", reflect.TypeOf((*MockUserTeamRepository)(nil).FindInvitedTeamsByUserId), userId)
 }
 
+// FindInvitedUsersByTeamId mocks base method.
+func (m *MockUserTeamRepository) FindInvitedUsersByTeamId(teamId string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindInvitedUsersByTeamId", teamId)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindInvitedUsersByTeamId indicates an expected call of FindInvitedUsersByTeamId.
+func (mr *MockUserTeamRepositoryMockRecorder) FindInvitedUsersByTeamId(teamId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindInvitedUsersByTeamId", reflect.TypeOf((*MockUserTeamRepository)(nil).FindInvitedUsersByTeamId), teamId)
+}
+
 // FindMembersByTeamId mocks base method.
 func (m *MockUserTeamRepository) FindMembersByTeamId(teamId string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/mock/mock_usecase_record.go
+++ b/mock/mock_usecase_record.go
@@ -141,16 +141,16 @@ func (mr *MockRecordUsecaseMockRecorder) SetVisibility(recordId, userId, isPubli
 }
 
 // UpdateRecord mocks base method.
-func (m *MockRecordUsecase) UpdateRecord(recordId, userId, enemyTeamName, place string, endsData []entity.DataPerEnd, date time.Time) (*entity.Record, error) {
+func (m *MockRecordUsecase) UpdateRecord(recordId, userId, enemyTeamName, place string, endsData []entity.DataPerEnd, date time.Time, isFirst, isPublic bool) (*entity.Record, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRecord", recordId, userId, enemyTeamName, place, endsData, date)
+	ret := m.ctrl.Call(m, "UpdateRecord", recordId, userId, enemyTeamName, place, endsData, date, isFirst, isPublic)
 	ret0, _ := ret[0].(*entity.Record)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateRecord indicates an expected call of UpdateRecord.
-func (mr *MockRecordUsecaseMockRecorder) UpdateRecord(recordId, userId, enemyTeamName, place, endsData, date interface{}) *gomock.Call {
+func (mr *MockRecordUsecaseMockRecorder) UpdateRecord(recordId, userId, enemyTeamName, place, endsData, date, isFirst, isPublic interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRecord", reflect.TypeOf((*MockRecordUsecase)(nil).UpdateRecord), recordId, userId, enemyTeamName, place, endsData, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRecord", reflect.TypeOf((*MockRecordUsecase)(nil).UpdateRecord), recordId, userId, enemyTeamName, place, endsData, date, isFirst, isPublic)
 }

--- a/mock/mock_usecase_team.go
+++ b/mock/mock_usecase_team.go
@@ -92,6 +92,21 @@ func (mr *MockTeamUsecaseMockRecorder) GetAllTeams() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllTeams", reflect.TypeOf((*MockTeamUsecase)(nil).GetAllTeams))
 }
 
+// GetDetailsByTeamId mocks base method.
+func (m *MockTeamUsecase) GetDetailsByTeamId(teamId string) (*entity.Team, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDetailsByTeamId", teamId)
+	ret0, _ := ret[0].(*entity.Team)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDetailsByTeamId indicates an expected call of GetDetailsByTeamId.
+func (mr *MockTeamUsecaseMockRecorder) GetDetailsByTeamId(teamId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDetailsByTeamId", reflect.TypeOf((*MockTeamUsecase)(nil).GetDetailsByTeamId), teamId)
+}
+
 // GetInvitedTeams mocks base method.
 func (m *MockTeamUsecase) GetInvitedTeams(userId string) ([]*entity.Team, error) {
 	m.ctrl.T.Helper()
@@ -105,6 +120,21 @@ func (m *MockTeamUsecase) GetInvitedTeams(userId string) ([]*entity.Team, error)
 func (mr *MockTeamUsecaseMockRecorder) GetInvitedTeams(userId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInvitedTeams", reflect.TypeOf((*MockTeamUsecase)(nil).GetInvitedTeams), userId)
+}
+
+// GetInvitedUsersByTeamId mocks base method.
+func (m *MockTeamUsecase) GetInvitedUsersByTeamId(teamId string) ([]*entity.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInvitedUsersByTeamId", teamId)
+	ret0, _ := ret[0].([]*entity.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInvitedUsersByTeamId indicates an expected call of GetInvitedUsersByTeamId.
+func (mr *MockTeamUsecaseMockRecorder) GetInvitedUsersByTeamId(teamId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInvitedUsersByTeamId", reflect.TypeOf((*MockTeamUsecase)(nil).GetInvitedUsersByTeamId), teamId)
 }
 
 // GetMembersByTeamId mocks base method.

--- a/mock/mock_usecase_user.go
+++ b/mock/mock_usecase_user.go
@@ -36,18 +36,19 @@ func (m *MockUserUsecase) EXPECT() *MockUserUsecaseMockRecorder {
 }
 
 // Authorize mocks base method.
-func (m *MockUserUsecase) Authorize(c echo.Context, name, email string) (*entity.User, error) {
+func (m *MockUserUsecase) Authorize(c echo.Context, idToken string) (*entity.User, *string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Authorize", c, name, email)
+	ret := m.ctrl.Call(m, "Authorize", c, idToken)
 	ret0, _ := ret[0].(*entity.User)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(*string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Authorize indicates an expected call of Authorize.
-func (mr *MockUserUsecaseMockRecorder) Authorize(c, name, email interface{}) *gomock.Call {
+func (mr *MockUserUsecaseMockRecorder) Authorize(c, idToken interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authorize", reflect.TypeOf((*MockUserUsecase)(nil).Authorize), c, name, email)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authorize", reflect.TypeOf((*MockUserUsecase)(nil).Authorize), c, idToken)
 }
 
 // DeleteUser mocks base method.


### PR DESCRIPTION
## やったこと
- 招待中ユーザー取得のエンドポイントを追加
## できるようになったこと

## 動作確認手順

## 確認してほしいこと
- [ ] TODO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint to retrieve invited users for a specific team: `GET /teams/:teamId/invited`.
	- Added functionality to fetch invited users through the `GetInvitedUsers` method in the team handler.
	- Expanded the `UserTeamRepository` interface with a method to find invited users by team ID.
	- Enhanced the `TeamUsecase` interface with new methods for retrieving team details, members, and invited users.

- **Bug Fixes**
	- Improved error handling in the new user retrieval methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->