### PR TITLE
fix: add record entity as argument of updaterecord

### DIFF
--- a/internal/handler/recordHandler.go
+++ b/internal/handler/recordHandler.go
@@ -256,6 +256,7 @@ func (h *RecordHandler) UpdateRecord() echo.HandlerFunc {
 		updatedRecord, err := h.recordUsecase.UpdateRecord(
 			recordId,
 			userId,
+      *req.Result,
 			*req.EnemyTeamName,
 			*req.Place,
 			*req.EndsData,

--- a/internal/usecase/record.go
+++ b/internal/usecase/record.go
@@ -14,7 +14,7 @@ type RecordUsecase interface {
 	GetRecordDetailsByRecordId(recordId string) (*entity.Record, error)
 	GetRecordIndicesByTeamId(teamId string) (*[]response.RecordIndex, error)
 	GetRecordsByTeamId(teamId string) (*[]entity.Record, error)
-	UpdateRecord(recordId, userId, enemyTeamName, place string, endsData []entity.DataPerEnd, date time.Time, isFirst bool, isPublic bool) (*entity.Record, error)
+	UpdateRecord(recordId, userId string, result entity.Result, enemyTeamName, place string, endsData []entity.DataPerEnd, date time.Time, isFirst bool, isPublic bool) (*entity.Record, error)
 	DeleteRecord(id string) error
 	SetVisibility(recordId, userId string, isPublic bool) (*entity.Record, error)
 }
@@ -113,7 +113,7 @@ func (u *recordUsecase) GetRecordsByTeamId(teamId string) (*[]entity.Record, err
 	return u.recordRepo.FindByTeamId(teamId)
 }
 
-func (u *recordUsecase) UpdateRecord(recordId, userId, enemyTeamName, place string, endsData []entity.DataPerEnd, date time.Time, isFirst, isPublic bool) (*entity.Record, error) {
+func (u *recordUsecase) UpdateRecord(recordId, userId string, result entity.Result, enemyTeamName, place string, endsData []entity.DataPerEnd, date time.Time, isFirst, isPublic bool) (*entity.Record, error) {
 
 	// Get the record by ID
 	record, err := u.recordRepo.FindByRecordId(recordId)
@@ -133,6 +133,9 @@ func (u *recordUsecase) UpdateRecord(recordId, userId, enemyTeamName, place stri
 	// Prepare the update struct
 	newRecord := record
 
+  if result != "" {
+    newRecord.SetResult(result)
+  }
 	if enemyTeamName != "" {
 		newRecord.SetEnemyTeamName(enemyTeamName)
 	}


### PR DESCRIPTION
## やったこと

- `result` エンティティを `UpdateRecord` の引数に追加

## できるようになったこと

省略

## 動作確認手順

省略

## 確認してほしいこと

省略

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced record updating functionality with additional parameters for more detailed updates.
	- Improved flexibility in setting results during record updates.

- **Bug Fixes**
	- Consistent error handling for invalid requests and internal server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->